### PR TITLE
Update README install docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To start the local IPFS daemon:
 brew services start ipfs
 ```
 
-Check the [Fission Installation Guide](https://guide.fission.codes/installation) for extended instructions for all platforms.
+Check the [Fission Installation Guide](https://guide.fission.codes/developers/installation) for extended instructions for all platforms.
 
 ### Installing Fission
 


### PR DESCRIPTION
I noticed yesterday that the installation instructions link was broken, this updates to the correct link.