### PR TITLE
Upgrade to Palmer Eldritch CLI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The `fission.yaml` configuration file for your app must be in the workspace root
 
 Register a new account with Fission or link to an existing Fission account.
 
-### Fission: Link Account to a Web Browser
+### Fission: Link Account
 
-Link your CLI account to a web browser.
+Link your account in a web browser or at the command line on another device.
 
 ### Fission: Show Current User
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The `fission.yaml` configuration file for your app must be in the workspace root
 
 Register a new account with Fission or link to an existing Fission account.
 
+### Fission: Link Account to a Web Browser
+
+Link your CLI account to a web browser.
+
 ### Fission: Show Current User
 
 Display your username.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "icon": "assets/logo.png",
   "activationEvents": [
     "onCommand:fissionCommand.setup",
+    "onCommand:fissionCommand.login",
     "onCommand:fissionCommand.whoami",
     "onCommand:fissionCommand.appRegister",
     "onCommand:fissionCommand.appInfo",
@@ -25,6 +26,10 @@
       {
         "command": "fissionCommand.setup",
         "title": "Fission: Setup"
+      },
+      {
+        "command": "fissionCommand.login",
+        "title": "Fission: Link Account to a Web Browser"
       },
       {
         "command": "fissionCommand.whoami",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       },
       {
         "command": "fissionCommand.login",
-        "title": "Fission: Link Account to a Web Browser"
+        "title": "Fission: Link Account"
       },
       {
         "command": "fissionCommand.whoami",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('fissionCommand.setup', sendCommand("fission setup", false))
   )
   context.subscriptions.push(
+    vscode.commands.registerCommand('fissionCommand.login', sendCommand("fission login", false))
+  )
+  context.subscriptions.push(
     vscode.commands.registerCommand('fissionCommand.whoami', sendCommand("fission whoami", true))
   )
 


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Add CLI-to-web linking

This PR updates the extension to add the `fission login` command as "Fission: Link Account".

## Test plan (required)

Test all commands in VSCode. Pressing `F5` in the project will start the debugger and open a new VSCode window with the updated extension. 

Note that you may want to disable the current version of the published plugin or you will see the old commands. 

## After Merge
* [x] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [x] Does this change require a release to be made? Is so please create and deploy the release


