### PR TITLE
Filter to make commands run in Fission terminal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ const sendCommand = (command: string, preserveFocus: boolean) => () => {
  */
 function getTerminal(): vscode.Terminal | undefined {
   const terminals = <vscode.Terminal[]>(<any>vscode.window).terminals
+    .filter((terminal: vscode.Terminal) => terminal.name === 'Fission')
   return terminals.length > 0
     ? terminals[0]
     : vscode.window.createTerminal("Fission")


### PR DESCRIPTION
This PR filters the available terminal windows to make sure we only run in a Fission one. This prevents the extension from interrupting an active process in another terminal window.

To test this out, open one terminal with a shell and run some process. Run a Fission command. The Fission command should open a new terminal to execute the command. Any additional commands should run in the Fission terminal window, regardless of which terminal currently has focus.